### PR TITLE
Fixes task typo on README.md

### DIFF
--- a/roles/os_firewall/README.md
+++ b/roles/os_firewall/README.md
@@ -31,7 +31,7 @@ Use iptables:
 ```
 ---
 - hosts: servers
-  task:
+  tasks:
   - import_role:
       name: os_firewall
     vars:


### PR DESCRIPTION
There is a typo on README from os_firewall role on iptables session. I just fixed the typo.